### PR TITLE
fix: correct critical typo in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Project Simulator
-Implimentation
+Implementation


### PR DESCRIPTION
This PR fixes the critical typo 'implimentation' to 'implementation' in README.md to prevent confusion for users.
